### PR TITLE
Implement admin teacher management

### DIFF
--- a/src/app/admin/dashboard/page.tsx
+++ b/src/app/admin/dashboard/page.tsx
@@ -1,20 +1,82 @@
 "use client";
-
 import axios from "axios";
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import toast from "react-hot-toast";
+
+interface Teacher {
+  _id: string;
+  username: string;
+  name: string;
+  email: string;
+}
 
 export default function AdminDashBoard() {
+  const [teachers, setTeachers] = useState<Teacher[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  const fetchTeachers = async () => {
+    try {
+      const res = await axios.get("/api/admin/teacher");
+      setTeachers(res.data.allTeacher);
+    } catch (err: any) {
+      toast.error(err.response?.data?.error || "Failed to fetch");
+    } finally {
+      setLoading(false);
+    }
+  };
+
   useEffect(() => {
-    const getAllTeacher = async () => {
-      try {
-        const response = await axios.get("/api/admin/teacher");
-        console.log(response);
-        console.log(response.data);
-      } catch (error: any) {
-        console.log(error);
-      }
-    };
-    getAllTeacher();
+    fetchTeachers();
   }, []);
-  return <div>Admin DashBoard Loaded sucessfuly</div>;
+
+  const handleDelete = async (id: string) => {
+    if (!confirm("Delete this teacher?")) return;
+    try {
+      await axios.delete(`/api/admin/teacher/${id}`);
+      toast.success("Teacher deleted");
+      fetchTeachers();
+    } catch (err: any) {
+      toast.error(err.response?.data?.error || "Delete failed");
+    }
+  };
+
+  if (loading) return <div>Loading...</div>;
+
+  return (
+    <div>
+      <h1 className="text-2xl font-semibold mb-4">Teachers</h1>
+      <table className="min-w-full bg-white border">
+        <thead>
+          <tr>
+            <th className="border px-2 py-1">Name</th>
+            <th className="border px-2 py-1">Email</th>
+            <th className="border px-2 py-1">Actions</th>
+          </tr>
+        </thead>
+        <tbody>
+          {teachers.map((t) => (
+            <tr key={t._id}>
+              <td className="border px-2 py-1">{t.name}</td>
+              <td className="border px-2 py-1">{t.email}</td>
+              <td className="border px-2 py-1 space-x-2">
+                <Link
+                  href={`/admin/teacher/${t._id}`}
+                  className="text-blue-600 underline"
+                >
+                  Edit
+                </Link>
+                <button
+                  onClick={() => handleDelete(t._id)}
+                  className="text-red-600"
+                >
+                  Delete
+                </button>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
 }

--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -1,0 +1,41 @@
+"use client";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import axios from "axios";
+import { Toaster } from "react-hot-toast";
+import toast from "react-hot-toast";
+
+export default function AdminLayout({ children }: { children: React.ReactNode }) {
+  const router = useRouter();
+  const handleLogout = async () => {
+    try {
+      await axios.post("/api/logout");
+      router.push("/admin/login");
+    } catch (err: any) {
+      toast.error(err.response?.data?.error || "Logout failed");
+    }
+  };
+  return (
+    <div className="min-h-screen flex">
+      <Toaster position="top-right" />
+      <aside className="w-60 bg-gray-800 text-white p-4 space-y-4">
+        <h2 className="text-lg font-semibold">Admin Panel</h2>
+        <nav className="space-y-2">
+          <Link href="/admin/dashboard" className="block hover:underline">
+            Dashboard
+          </Link>
+          <Link href="/admin/teacher/create" className="block hover:underline">
+            Create Teacher
+          </Link>
+          <button
+            onClick={handleLogout}
+            className="mt-4 text-left hover:underline"
+          >
+            Logout
+          </button>
+        </nav>
+      </aside>
+      <main className="flex-1 p-6 overflow-x-auto">{children}</main>
+    </div>
+  );
+}

--- a/src/app/admin/teacher/[id]/page.tsx
+++ b/src/app/admin/teacher/[id]/page.tsx
@@ -1,0 +1,141 @@
+"use client";
+import { useEffect, useState } from "react";
+import axios from "axios";
+import { useRouter } from "next/navigation";
+import toast from "react-hot-toast";
+
+export default function EditTeacher({ params }: { params: { id: string } }) {
+  const { id } = params;
+  const router = useRouter();
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [photoFile, setPhotoFile] = useState<File | null>(null);
+  const [form, setForm] = useState({
+    username: "",
+    name: "",
+    email: "",
+    password: "",
+    age: "",
+    mobileNo: "",
+    address: "",
+    photo: "",
+  });
+
+  useEffect(() => {
+    const fetchTeacher = async () => {
+      try {
+        const res = await axios.get(`/api/admin/teacher/${id}`);
+        const t = res.data.teacher;
+        setForm({
+          username: t.username || "",
+          name: t.name || "",
+          email: t.email || "",
+          password: "",
+          age: String(t.profile?.age || ""),
+          mobileNo: t.profile?.mobileNo || "",
+          address: t.profile?.address || "",
+          photo: t.profile?.photo || "",
+        });
+      } catch (err: any) {
+        toast.error("Failed to load teacher");
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetchTeacher();
+  }, [id]);
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setForm({ ...form, [e.target.name]: e.target.value });
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    try {
+      setSaving(true);
+      let photoUrl = form.photo;
+      if (photoFile) {
+        const uploadData = new FormData();
+        uploadData.append("file", photoFile);
+        const uploadRes = await axios.post("/api/upload", uploadData);
+        photoUrl = uploadRes.data.imageUrl;
+      }
+      const body = {
+        ...form,
+        age: Number(form.age),
+        photo: photoUrl,
+      };
+      await axios.patch(`/api/admin/teacher/${id}`, body);
+      toast.success("Teacher updated");
+      router.push("/admin/dashboard");
+    } catch (err: any) {
+      toast.error(err.response?.data?.error || "Update failed");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  if (loading) return <div>Loading...</div>;
+
+  return (
+    <div className="max-w-xl mx-auto">
+      <h1 className="text-2xl font-semibold mb-4">Edit Teacher</h1>
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <input
+          className="w-full border p-2"
+          name="username"
+          placeholder="Username"
+          value={form.username}
+          onChange={handleChange}
+        />
+        <input
+          className="w-full border p-2"
+          name="name"
+          placeholder="Name"
+          value={form.name}
+          onChange={handleChange}
+        />
+        <input
+          className="w-full border p-2"
+          name="email"
+          placeholder="Email"
+          value={form.email}
+          onChange={handleChange}
+        />
+        <input
+          className="w-full border p-2"
+          type="password"
+          name="password"
+          placeholder="Password"
+          value={form.password}
+          onChange={handleChange}
+        />
+        <input
+          className="w-full border p-2"
+          name="age"
+          placeholder="Age"
+          value={form.age}
+          onChange={handleChange}
+        />
+        <input
+          className="w-full border p-2"
+          name="mobileNo"
+          placeholder="Mobile"
+          value={form.mobileNo}
+          onChange={handleChange}
+        />
+        <input
+          className="w-full border p-2"
+          name="address"
+          placeholder="Address"
+          value={form.address}
+          onChange={handleChange}
+        />
+        <input type="file" onChange={(e) => setPhotoFile(e.target.files ? e.target.files[0] : null)} />
+        <button type="submit" disabled={saving} className="bg-blue-600 text-white px-4 py-2 rounded">
+          {saving ? "Saving..." : "Update"}
+        </button>
+      </form>
+    </div>
+  );
+}

--- a/src/app/admin/teacher/create/page.tsx
+++ b/src/app/admin/teacher/create/page.tsx
@@ -1,0 +1,119 @@
+"use client";
+import { useState } from "react";
+import axios from "axios";
+import { useRouter } from "next/navigation";
+import toast from "react-hot-toast";
+
+export default function CreateTeacher() {
+  const router = useRouter();
+  const [loading, setLoading] = useState(false);
+  const [photoFile, setPhotoFile] = useState<File | null>(null);
+  const [form, setForm] = useState({
+    username: "",
+    name: "",
+    email: "",
+    password: "",
+    age: "",
+    mobileNo: "",
+    address: "",
+  });
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setForm({ ...form, [e.target.name]: e.target.value });
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    try {
+      setLoading(true);
+      let photoUrl = "";
+      if (photoFile) {
+        const uploadData = new FormData();
+        uploadData.append("file", photoFile);
+        const uploadRes = await axios.post("/api/upload", uploadData);
+        photoUrl = uploadRes.data.imageUrl;
+      }
+      const data = new FormData();
+      Object.entries(form).forEach(([k, v]) => data.append(k, v));
+      data.append("photo", photoUrl);
+      await axios.post("/api/admin/teacher/create", data);
+      toast.success("Teacher created");
+      router.push("/admin/dashboard");
+    } catch (err: any) {
+      toast.error(err.response?.data?.error || "Failed to create teacher");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="max-w-xl mx-auto">
+      <h1 className="text-2xl font-semibold mb-4">Create Teacher</h1>
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <input
+          className="w-full border p-2"
+          name="username"
+          placeholder="Username"
+          value={form.username}
+          onChange={handleChange}
+        />
+        <input
+          className="w-full border p-2"
+          name="name"
+          placeholder="Name"
+          value={form.name}
+          onChange={handleChange}
+        />
+        <input
+          className="w-full border p-2"
+          name="email"
+          placeholder="Email"
+          value={form.email}
+          onChange={handleChange}
+        />
+        <input
+          className="w-full border p-2"
+          type="password"
+          name="password"
+          placeholder="Password"
+          value={form.password}
+          onChange={handleChange}
+        />
+        <input
+          className="w-full border p-2"
+          name="age"
+          placeholder="Age"
+          value={form.age}
+          onChange={handleChange}
+        />
+        <input
+          className="w-full border p-2"
+          name="mobileNo"
+          placeholder="Mobile"
+          value={form.mobileNo}
+          onChange={handleChange}
+        />
+        <input
+          className="w-full border p-2"
+          name="address"
+          placeholder="Address"
+          value={form.address}
+          onChange={handleChange}
+        />
+        <input
+          type="file"
+          onChange={(e) =>
+            setPhotoFile(e.target.files ? e.target.files[0] : null)
+          }
+        />
+        <button
+          type="submit"
+          disabled={loading}
+          className="bg-blue-600 text-white px-4 py-2 rounded"
+        >
+          {loading ? "Submitting..." : "Create"}
+        </button>
+      </form>
+    </div>
+  );
+}

--- a/src/app/api/admin/teacher/[id]/route.ts
+++ b/src/app/api/admin/teacher/[id]/route.ts
@@ -1,0 +1,44 @@
+import { connect } from "@/dbConfig/dbConfig";
+import { NextRequest, NextResponse } from "next/server";
+import Teachers from "@/models/teacherModel";
+
+export async function GET(req: NextRequest, { params }: { params: { id: string } }) {
+  try {
+    await connect();
+    const teacher = await Teachers.findById(params.id).select("-passwordHash");
+    if (!teacher) {
+      return NextResponse.json({ error: "Teacher not found" }, { status: 404 });
+    }
+    return NextResponse.json({ teacher }, { status: 200 });
+  } catch (error) {
+    return NextResponse.json({ error: "Failed to fetch" }, { status: 500 });
+  }
+}
+
+export async function PATCH(req: NextRequest, { params }: { params: { id: string } }) {
+  try {
+    await connect();
+    const body = await req.json();
+    const { username, name, email, password, age, mobileNo, address, photo } = body;
+    const updateData: any = { username, name, email };
+    if (password) updateData.passwordHash = password;
+    updateData.profile = { age, mobileNo, address, photo };
+    const teacher = await Teachers.findByIdAndUpdate(params.id, updateData, { new: true });
+    if (!teacher) {
+      return NextResponse.json({ error: "Teacher not found" }, { status: 404 });
+    }
+    return NextResponse.json({ teacher }, { status: 200 });
+  } catch (error) {
+    return NextResponse.json({ error: "Update failed" }, { status: 500 });
+  }
+}
+
+export async function DELETE(req: NextRequest, { params }: { params: { id: string } }) {
+  try {
+    await connect();
+    await Teachers.findByIdAndDelete(params.id);
+    return NextResponse.json({ message: "Teacher deleted" }, { status: 200 });
+  } catch (error) {
+    return NextResponse.json({ error: "Delete failed" }, { status: 500 });
+  }
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -11,7 +11,7 @@ export async function middleware(request: NextRequest) {
   const path = request.nextUrl.pathname; //get the path
   const token = request.cookies.get("token")?.value || ""; //get the token
 
-  const isAdminRoute = path.startsWith("/admin/dashboard");
+  const isAdminRoute = path.startsWith("/admin/dashboard") || path.startsWith("/admin/teacher");
   const isTeacherRoute = path.startsWith("/teacher/dashboard");
 
   if (isAdminRoute || isTeacherRoute) {
@@ -39,5 +39,9 @@ export async function middleware(request: NextRequest) {
 }
 
 export const config = {
-  matcher: ["/admin/dashboard", "/teacher/dashboard"],
+  matcher: [
+    "/admin/dashboard/:path*",
+    "/admin/teacher/:path*",
+    "/teacher/dashboard",
+  ],
 };


### PR DESCRIPTION
## Summary
- add admin layout with sidebar navigation and logout
- create dashboard with teacher list and actions
- add create-teacher form using the S3 upload API
- add edit-teacher page to update details
- implement teacher CRUD API endpoints
- protect admin routes in middleware

## Testing
- `npm run lint` *(fails: many lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_688654cff3f0832b9a0f17d13f58c038